### PR TITLE
fix: Use dynamic tag from settings for feed retrieval, improve `pubDate` handling and add ribbon refresh button

### DIFF
--- a/src/RSSParser.ts
+++ b/src/RSSParser.ts
@@ -6,7 +6,7 @@ export class RSSParser {
 		const items = result.elements
 			.filter((e) => e.name == "rss" || e.name == "feed")[0]
 			.elements[0].elements.filter(
-				(element) => element.name == "item" || element.name == "entry"
+				(element) => element.name == "item" || element.name == "entry",
 			);
 
 		const itemsResults = [];

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -2,11 +2,45 @@ import { request, Notice, Vault, htmlToMarkdown, Platform } from "obsidian";
 import { DateTime } from "luxon";
 import { RSSParser } from "./RSSParser";
 import * as DOMPurify from "isomorphic-dompurify";
-import { Readability} from "@mozilla/readability";
+import { Readability } from "@mozilla/readability";
 
 function convertToValidFilename(string: string): string {
 	// eslint-disable-next-line no-useless-escape
 	return string.replace(/[\/|\\:*?"<>]/g, " ");
+}
+
+const RSS_FORMATS = [
+	DateTime.fromRFC2822,
+	DateTime.fromHTTP, // covers RFC 1123 / RFC 850 / asctime
+	DateTime.fromISO,
+	DateTime.fromSQL,
+];
+
+export function parsePubDate(raw?: string) {
+	if (!raw) return null;
+
+	const s = raw.trim();
+
+	let dt;
+
+	for (const fn of RSS_FORMATS) {
+		dt = fn(s, { setZone: true });
+		if (dt.isValid) return dt.toISODate();
+	}
+
+	// Common RSS fallback: "Thu, 27 Nov 2025 17:17:07 +0000"
+	dt = DateTime.fromFormat(s, "EEE, dd LLL yyyy HH:mm:ss ZZZ", { setZone: true });
+	if (dt.isValid) return dt.toISODate();
+
+	// Another common variant with GMT
+	dt = DateTime.fromFormat(s, "EEE, dd LLL yyyy HH:mm:ss 'GMT'", { zone: "UTC" });
+	if (dt.isValid) return dt.toISODate();
+
+	// Last resort: native Date parse
+	const js = new Date(s);
+	if (!Number.isNaN(js.getTime())) return DateTime.fromJSDate(js, { zone: "utc" }).toISODate();
+
+	return s;
 }
 
 export default class FeedsFolder {
@@ -22,7 +56,7 @@ export default class FeedsFolder {
 		feedUrl: string,
 		template: string,
 		newestNum: number,
-		loadWebpageText: boolean
+		loadWebpageText: boolean,
 	): Promise<void> {
 		if (!newestNum) {
 			newestNum = 5;
@@ -33,7 +67,7 @@ export default class FeedsFolder {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		content.items.slice(0, newestNum).forEach(async (item: any) => {
 			let mdcontent = htmlToMarkdown(item.content);
-			if(loadWebpageText){
+			if (loadWebpageText) {
 				mdcontent = await this.loadWebpageText(item.link);
 			}
 			const images = mdcontent.match(/!\[.*?\]\((.*?)\)/) ?? ["", ""];
@@ -64,7 +98,7 @@ export default class FeedsFolder {
 		}
 	}
 
-	async loadWebpageText(url:string){
+	async loadWebpageText(url: string) {
 		// the code is from https://github.com/DominikPieper/obsidian-ReadItLater/blob/master/src/parsers/WebsiteParser.ts
 		const link = new URL(url);
 		const response = await request({ method: "GET", url: link.href });
@@ -96,6 +130,6 @@ export default class FeedsFolder {
 			.replaceAll("{{item.content}}", htmlToMarkdown(item.content) ?? "")
 			.replaceAll("{{item.author}}", item.author ?? "")
 			.replaceAll("{{item.link}}", item.link ?? "")
-			.replaceAll("{{item.pubDate}}", DateTime.fromHTTP(item.pubDate).toISODate() ?? "");
+			.replaceAll("{{item.pubDate}}", parsePubDate(item.pubDate) ?? "");
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ export default class RSSCopyistPlugin extends Plugin {
 			id: "get-all-feeds",
 			name: "Get the newest articles from all feeds",
 			callback: async () => {
-				const files = getNotesWithTag(this.app, "feed");
+				const files = getNotesWithTag(this.app, this.settings.tag);
 				files.forEach(async (file) => {
 					const folder = await this.getFeedFolder(file);
 					await this.parseFeed(folder);

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,13 @@ export default class RSSCopyistPlugin extends Plugin {
 				return true;
 			},
 		});
+		this.addRibbonIcon("list-restart", "Get the newest articles from all feeds", () => {
+			const files = getNotesWithTag(this.app, this.settings.tag);
+			files.forEach(async (file) => {
+				const folder = await this.getFeedFolder(file);
+				await this.parseFeed(folder);
+			});
+		});
 		this.addCommand({
 			id: "get-all-feeds",
 			name: "Get the newest articles from all feeds",
@@ -44,7 +51,7 @@ export default class RSSCopyistPlugin extends Plugin {
 				const files = getNotesWithTag(this.app, this.settings.tag);
 				for (const file of files) {
 					const folder = await this.getFeedFolder(file);
-					await this.app.vault.delete(folder,true);
+					await this.app.vault.delete(folder, true);
 				}
 			},
 		});
@@ -78,14 +85,14 @@ export default class RSSCopyistPlugin extends Plugin {
 				feedMetadata?.["url"],
 				template,
 				parseInt(feedMetadata?.["newestNum"]),
-				this.settings.loadWebpageText
+				this.settings.loadWebpageText,
 			);
 		}
 	}
 
 	getFeedMetadata(folder: TFolder) {
 		const result = this.app.vault.getAbstractFileByPath(
-			folder.parent.path + "/" + folder.name + ".md"
+			folder.parent.path + "/" + folder.name + ".md",
 		);
 		if (result instanceof TFile) {
 			return this.app.metadataCache.getFileCache(result)?.frontmatter;


### PR DESCRIPTION
Thanks for the plugin and I'm using it to keep track of my course updates on Padlet. Here are my minor modifications to solve the issues I've encountered:

The tag is hardcoded in the "refresh all" action, which is fixed in https://github.com/aoout/obsidian-rss-copyist/pull/9/commits/760ab450fb9ff4097bf647a15e2182e2b8510fd2 .

Added a ribbon button for "refresh all", and improved the `pubDate` handling to deal with those not in HTTP Header format, and fallback to its plaintext. 